### PR TITLE
examples: populate data.lux with sensor value

### DIFF
--- a/examples/full_featured/plotly-example-full.device.nut
+++ b/examples/full_featured/plotly-example-full.device.nut
@@ -50,6 +50,7 @@ function getReadings()
     // Get the light level
 
     local lux = lightSensor.read()
+    data.lux = lux
 
     // Day or night?
 

--- a/examples/minimal/plotly-example-minimal.device.nut
+++ b/examples/minimal/plotly-example-minimal.device.nut
@@ -50,6 +50,7 @@ function getReadings()
     // Get the light level
 
     local lux = lightSensor.read()
+    data.lux = lux
 
     // Day or night?
 


### PR DESCRIPTION
this commit ensures `data.lux` is set with the value of the light
sensor. the examples previously assigned the light sensor value into a
local `lux` variable, and used that to conditionally set `data.day` but
it was never used to set `data.lux`, resulting in a constant value of 0
